### PR TITLE
Missing macros and ARM Cortex fencing

### DIFF
--- a/src/ControlBinop.c
+++ b/src/ControlBinop.c
@@ -31,7 +31,7 @@ static float cBinop_perform_op(BinopType op, float f, const float k) {
     case HV_BINOP_MOD_BIPOLAR: return (float) ((int) f % (int) k);
     case HV_BINOP_MOD_UNIPOLAR: {
       f = (k == 0.0f) ? 0.0f : (float) ((int) f % (int) k);
-      return (f < 0.0f) ? f + fabsf(k) : f;
+      return (f < 0.0f) ? f + hv_abs_f(k) : f;
     }
     case HV_BINOP_BIT_LEFTSHIFT: return (float) (((int) f) << ((int) k));
     case HV_BINOP_BIT_RIGHTSHIFT: return (float) (((int) f) >> ((int) k));
@@ -48,8 +48,8 @@ static float cBinop_perform_op(BinopType op, float f, const float k) {
     case HV_BINOP_GREATER_THAN_EQL: return (f >= k) ? 1.0f : 0.0f;
     case HV_BINOP_MAX: return hv_max_f(f, k);
     case HV_BINOP_MIN: return hv_min_f(f, k);
-    case HV_BINOP_POW: return (f > 0.0f) ? powf(f, k) : 0.0f;
-    case HV_BINOP_ATAN2: return ((f == 0.0f) && (k == 0.0f)) ? 0.0f : atan2f(f, k);
+    case HV_BINOP_POW: return (f > 0.0f) ? hv_pow_f(f, k) : 0.0f;
+    case HV_BINOP_ATAN2: return ((f == 0.0f) && (k == 0.0f)) ? 0.0f : hv_atan2_f(f, k);
     default: return 0.0f;
   }
 }

--- a/src/HvLightPipe.c
+++ b/src/HvLightPipe.c
@@ -20,11 +20,13 @@
 #include <xmmintrin.h>
 #define hv_sfence() _mm_sfence()
 #elif __arm__ || HV_SIMD_NEON
-  #if __ARM_ACLE
+  #ifdef __ARM_ACLE
     #include <arm_acle.h>
     // https://msdn.microsoft.com/en-us/library/hh875058.aspx#BarrierRestrictions
     // http://doxygen.reactos.org/d8/d47/armintr_8h_a02be7ec76ca51842bc90d9b466b54752.html
     #define hv_sfence() __dmb(0xE) /* _ARM_BARRIER_ST */
+  #elif defined ARM_CORTEX
+    #define hv_sfence() __ASM volatile ("dmb 0xF":::"memory")
   #else
     // http://stackoverflow.com/questions/19965076/gcc-memory-barrier-sync-synchronize-vs-asm-volatile-memory
     #define hv_sfence() __sync_synchronize()
@@ -32,9 +34,6 @@
 #elif HV_WIN
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684208(v=vs.85).aspx
 #define hv_sfence() _WriteBarrier()
-#elif ARM_CORTEX
-    #include <arm_acle.h>
-    #define hv_sfence() __dmb(0xE) /* _ARM_BARRIER_ST */
 #else
 #define hv_sfence() __asm__ volatile("" : : : "memory")
 #endif

--- a/src/HvLightPipe.c
+++ b/src/HvLightPipe.c
@@ -32,6 +32,9 @@
 #elif HV_WIN
 // https://msdn.microsoft.com/en-us/library/windows/desktop/ms684208(v=vs.85).aspx
 #define hv_sfence() _WriteBarrier()
+#elif ARM_CORTEX
+    #include <arm_acle.h>
+    #define hv_sfence() __dmb(0xE) /* _ARM_BARRIER_ST */
 #else
 #define hv_sfence() __asm__ volatile("" : : : "memory")
 #endif


### PR DESCRIPTION
Two commits:
- fixed ControlBinop.c to use the heavy macro versions of maths functions
- use the right barrier for ARM Cortex based on macro
